### PR TITLE
Add recipes for CORE3D metrics

### DIFF
--- a/recipes/laspy/build.sh
+++ b/recipes/laspy/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install --single-version-externally-managed --record=record.txt

--- a/recipes/laspy/meta.yaml
+++ b/recipes/laspy/meta.yaml
@@ -1,0 +1,32 @@
+{% set version = "1.5.1" %}
+
+package:
+  name: laspy
+  version: {{ version }}
+
+source:
+  url: https://github.com/laspy/laspy/archive/{{ version }}.tar.gz
+  sha256: 3dec2f9204fedbe0cdfb124ef796272b03da858cf1a0f979002b1297d3c78ff9
+
+build:
+  number: 0
+  noarch: python
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - numpy
+  run:
+    - python
+    - numpy
+
+test:
+  imports:
+    - laspy
+
+about:
+  home: https://github.com/laspy/laspy
+  license: BSD
+  license_file: LICENSE.txt
+  summary: Native Python ASPRS LAS read/write library

--- a/recipes/pubgeo-core3d-metrics/build.sh
+++ b/recipes/pubgeo-core3d-metrics/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install --single-version-externally-managed --record=record.txt

--- a/recipes/pubgeo-core3d-metrics/meta.yaml
+++ b/recipes/pubgeo-core3d-metrics/meta.yaml
@@ -1,0 +1,36 @@
+{% set version = "0.1.0" %}
+
+package:
+  name: pubgeo-core3d-metrics
+  version: {{ version }}
+
+source:
+  git_rev: 828f511b259f870adab5a8a6eeaf022822fe65c0
+  git_url: https://github.com/pubgeo/core3d-metrics.git
+
+build:
+  number: 0
+  noarch: python
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - gdal
+    - laspy
+    - matplotlib
+    - numpy
+    - scipy
+    - jsonschema
+    - pubgeo-tools
+
+test:
+  imports:
+    - core3dmetrics
+
+about:
+  home: https://github.com/pubgeo/core3d-metrics
+  license: MIT
+  summary: Performs metric analysis for 3D models

--- a/recipes/pubgeo-tools/build.sh
+++ b/recipes/pubgeo-tools/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+mkdir build
+cd build
+
+BUILD_CONFIG=Release
+
+cmake -G "Ninja" \
+    -DCMAKE_BUILD_TYPE=$BUILD_CONFIG \
+    -DCMAKE_PREFIX_PATH:PATH="${PREFIX}" \
+    -DCMAKE_INSTALL_PREFIX:PATH="${PREFIX}" \
+    -DPUBGEO_INSTALL_ALIGN3D:BOOL=ON \
+    -DPUBGEO_INSTALL_SHR3D:BOOL=ON \
+    ..
+
+ninja install

--- a/recipes/pubgeo-tools/meta.yaml
+++ b/recipes/pubgeo-tools/meta.yaml
@@ -1,0 +1,28 @@
+{% set version = "0.1.0" %}
+
+package:
+  name: pubgeo-tools
+  version: {{ version }}
+
+source:
+  git_rev: 5223661082f13073f4e0ba0245d777f7292b65c8
+  git_url: https://github.com/pubgeo/pubgeo.git
+
+build:
+  number: 0
+  skip: True  # [not linux]
+
+requirements:
+  build:
+    - cmake
+    - ninja
+    - libgdal
+    - libpdal
+  run:
+    - libgdal
+    - libpdal
+
+about:
+  home: http://www.jhuapl.edu/pubgeo.html
+  license: MIT
+  summary: Geospatial tools for 3D registration and scene classification


### PR DESCRIPTION
- Add recipe for CORE3D metrics (https://github.com/pubgeo/core3d-metrics)
- Add recipe for pubgeo tools (https://github.com/pubgeo/pubgeo); core3d-metrics requires the `align3d` tool
- Add recipe for laspy, a dependency of core3d-metrics

The recipes are ready to be reviewed/tested, but this is marked WIP until the following PRs are merged and the recipes updated:
- [x] https://github.com/pubgeo/pubgeo/pull/19
- [ ] https://github.com/pubgeo/pubgeo/pull/20
- [ ] https://github.com/pubgeo/pubgeo/pull/21
- [x] https://github.com/pubgeo/core3d-metrics/pull/23
- [x] https://github.com/pubgeo/core3d-metrics/pull/24