### PR TITLE
libpdal: Add CMake to build requirements

### DIFF
--- a/recipes/libpdal/meta.yaml
+++ b/recipes/libpdal/meta.yaml
@@ -17,6 +17,7 @@ build:
 
 requirements:
   build:
+    - cmake
     - jsoncpp 1.8.3.*
     - libgdal 2.2.3.*
     - numpy >=1.5


### PR DESCRIPTION
Because libpdal's build script uses CMake, the "cmake" package should be listed in the build requirements. This fixes the following error if CMake is not installed on the host:

    /home/user/miniconda3/conda-bld/libpdal_1527003090859/work/conda_build.sh: line 113: cmake: command not found