### PR TITLE
Loosen libgdal pinned version; depend on conda-forge PDAL

### DIFF
--- a/recipes/gaia/meta.yaml
+++ b/recipes/gaia/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - pillow
     - geopandas
     - gdal 2.2.*
-    - pdal 1.6
+    - python-pdal >=2.0.0
     - celery >=3.1.20
     - psycopg2 >=2.6.1
     - geoalchemy2 >=0.2.6

--- a/recipes/gaia/meta.yaml
+++ b/recipes/gaia/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - shapely
     - pillow
     - geopandas
-    - gdal 2.2.3
+    - gdal 2.2.*
     - pdal 1.6
     - celery >=3.1.20
     - psycopg2 >=2.6.1

--- a/recipes/libpdal/meta.yaml
+++ b/recipes/libpdal/meta.yaml
@@ -20,14 +20,14 @@ requirements:
     - cmake
     - jsoncpp 1.8.3.*
     - json-c 0.12.1.*
-    - libgdal 2.2.3.*
+    - libgdal 2.2.*
     - numpy >=1.5
     - vc 9  # [win and py27]
     - vc 14  # [win and (py35 or py36)]
   run:
     - jsoncpp 1.8.3.*
     - json-c 0.12.1.*
-    - libgdal 2.2.3.*
+    - libgdal 2.2.*
     - numpy >=1.5
     - sqlite 3.20.*
     - vc 9  # [win and py27]

--- a/recipes/pubgeo-tools/fix-conda-forge-pdal-link.patch
+++ b/recipes/pubgeo-tools/fix-conda-forge-pdal-link.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e6ab2af..8d2de54 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -29,6 +29,9 @@ endif()
+ FIND_PACKAGE(PDAL 1.4.0 REQUIRED)
+ LINK_DIRECTORIES(${PDAL_LIBRARY_DIRS})
+ 
++# Use old ABI for std::string to fix linker error with conda-forge pdal package
++add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
++
+ if (CMAKE_COMPILER_IS_GNUCXX)
+        SET( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -O3" )
+ ENDIF()

--- a/recipes/pubgeo-tools/meta.yaml
+++ b/recipes/pubgeo-tools/meta.yaml
@@ -7,6 +7,11 @@ package:
 source:
   git_rev: 5223661082f13073f4e0ba0245d777f7292b65c8
   git_url: https://github.com/pubgeo/pubgeo.git
+  patches:
+    # Compile with PDAL 1.7
+    - pdal-1.7.patch
+    # Fix error linking with conda-forge PDAL
+    - fix-conda-forge-pdal-link.patch
 
 build:
   number: 0
@@ -17,10 +22,10 @@ requirements:
     - cmake
     - ninja
     - libgdal
-    - libpdal
+    - pdal >=1.7.0
   run:
     - libgdal
-    - libpdal
+    - pdal >=1.7.0
 
 about:
   home: http://www.jhuapl.edu/pubgeo.html

--- a/recipes/pubgeo-tools/pdal-1.7.patch
+++ b/recipes/pubgeo-tools/pdal-1.7.patch
@@ -1,0 +1,26 @@
+diff --git a/src/align3d/plugin.cpp b/src/align3d/plugin.cpp
+index 25c50d1..fecdc64 100644
+--- a/src/align3d/plugin.cpp
++++ b/src/align3d/plugin.cpp
+@@ -29,8 +29,6 @@
+ #include "orthoimage.h"
+ #include "plugin.hpp"
+ 
+-#include <pdal/pdal_macros.hpp>
+-
+ namespace pdal
+ {
+ 
+diff --git a/src/shr3d/plugin.cpp b/src/shr3d/plugin.cpp
+index 9e84eee..f095c3c 100644
+--- a/src/shr3d/plugin.cpp
++++ b/src/shr3d/plugin.cpp
+@@ -29,8 +29,6 @@
+ #include "plugin.hpp"
+ #include "shr3d.h"
+ 
+-#include <pdal/pdal_macros.hpp>
+-
+ namespace pdal
+ {
+ 

--- a/recipes/texture-atlas/meta.yaml
+++ b/recipes/texture-atlas/meta.yaml
@@ -3,8 +3,7 @@ package:
   version: {{ environ['GIT_DESCRIBE_TAG'] ~ "." ~ environ['GIT_DESCRIBE_NUMBER'] ~ "." ~ environ['GIT_DESCRIBE_HASH'] }}
 
 source:
-#  git_rev: {{ sha }}
-  git_branch: master
+  git_rev: 30e1a07ba536329c49558816537cc4c1204e56ec
   git_url: git@gitlab.kitware.com:core3d/core3d-keu.git
   patches:
     - gdal-headers.patch

--- a/recipes/texture-atlas/meta.yaml
+++ b/recipes/texture-atlas/meta.yaml
@@ -16,12 +16,12 @@ requirements:
     - vtk v8.1.1.*    # vtk from kitware-geospatial
     - eigen 3.3.3.*
     - opencv 3.3.1.*
-    - libgdal 2.2.3.*
+    - libgdal 2.2.*
   run:
     - vtk v8.1.1.*    # vtk from kitware-geospatial
     - eigen 3.3.3.*
     - opencv 3.3.1.*
-    - libgdal 2.2.3.*
+    - libgdal 2.2.*
 
 test:
   commands:


### PR DESCRIPTION
When new patch revisions of the libgdal packages are released on conda-forge, the old versions are labelled as 'broken'. These 'broken' packages aren't found when used as a dependency and don't show up in searches.

This change loosens the pinned version of gdal/libgdal to allow patch updates, as recommend in https://github.com/conda-forge/gdal-feedstock/issues/212.

Additionally, this change removes the dependency on the libpdal/pdal packages from this repository in favor of the pdal/python-pdal packages on conda-forge. This avoids problems building that package (see comments in this pull request) and reduces maintenance burden.

Fixes #14 
Fixes #21 