### PR TITLE
Avoid missing library for opencv.

### DIFF
--- a/recipes/texture-atlas/meta.yaml
+++ b/recipes/texture-atlas/meta.yaml
@@ -17,14 +17,14 @@ requirements:
     - opencv 3.3.1.*
     - libgdal 2.2.*
     # otherwise we get an undefined error
-    - x264 20131218 # [osx]
+    - x264 20131218
   run:
     - vtk v8.1.1.*    # vtk from kitware-geospatial
     - eigen 3.3.3.*
     - opencv 3.3.1.*
     - libgdal 2.2.*
     # otherwise we get an undefined error
-    - x264 20131218 # [osx]
+    - x264 20131218
 
 test:
   commands:


### PR DESCRIPTION
This is the error that this solved:

Traceback (most recent call last):
  File "../../../src/tools/align_buildings.py", line 4, in <module>
    import cv2
ImportError: libx264.so.138: cannot open shared object file: No such file or directory