### PR TITLE
Fix texture-atlas conda build

### DIFF
--- a/recipes/texture-atlas/meta.yaml
+++ b/recipes/texture-atlas/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     # otherwise we get an undefined error
     - x264 20131218
     - libboost 1.67.*
+    - kealib 1.4.7.*
 
 test:
   commands:


### PR DESCRIPTION
- This fixes the build of the texture-atlas conda package.
- In addition to this change, the **libgdal** dependency needs to be downloaded from _conda-forge/label/broken_ because the recent **libgdal** builds from _conda-forge_ cause many errors.
- _conda-forge/label/broken_ has to be added when we build or install texture-atlas.