### PR TITLE
Updated pubgeo-core3d-metrics recipe

### DIFF
--- a/recipes/pubgeo-core3d-metrics/meta.yaml
+++ b/recipes/pubgeo-core3d-metrics/meta.yaml
@@ -5,11 +5,11 @@ package:
   version: {{ version }}
 
 source:
-  git_rev: cd0def2d50515128c403476e0ff8c37cffd3317e
+  git_rev: eaed3ee93e0da0947c6530c65e142959e36fb528
   git_url: https://github.com/pubgeo/core3d-metrics.git
 
 build:
-  number: 6
+  number: 7
   noarch: python
 
 requirements:


### PR DESCRIPTION
$ git shortlog cd0def2..eaed3ee --no-merges
leicham1 (1):
      Bulk Update

Notes from the "Bulk Update" commit:

New optional config file settings
    [OPTIONS]
    AlignModel   # Enable/Disable align3d.  (Default: True)
    SaveAligned  # Save input images post alignment as GeoTIFFs (Default: False)

threshold_geometry_metrics.py
   Updated footprint error plot with new color scheme

run_geometrics.py
   Added new command line arguments.  Option to enable/disable saving plots, overrides config file.  Option to enable saving aligned images
   Added magnitude of registration offset to results JSON as "geolocation_error"

threshold_material_metrics.py
   Added material plots that is colored and labeled
   Added metrics of label-wise and mean IOU
   Updated material metrics to account for intermediate asphalt category
   Added confusion matrix to output json file